### PR TITLE
Avoid building artifacts twice by adding --config-only to iOS cloud build and deploy setup

### DIFF
--- a/src/content/deployment/cd.md
+++ b/src/content/deployment/cd.md
@@ -188,7 +188,7 @@ secrets in pull requests that you accept and merge.
            (for example, `osx_image: xcode9.2`).
     * In the script phase of the CI task:
          * Run `flutter build appbundle` or
-           `flutter build ios --release --no-codesign`,
+           `flutter build ios --release --no-codesign --config-only`,
            depending on the platform.
          * `cd android` or `cd ios`
          * `bundle exec fastlane [name of the lane]`


### PR DESCRIPTION
According to the current Cloud build and deploy setup iOS guidelines, the pipeline builds the artifact twice unless the --config-only parameter is specified.

## Presubmit checklist

- [ ] **If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.** 
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [X] This PR doesn't contain automatically generated corrections (generated by Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
